### PR TITLE
fix: Another path for duplicate dives

### DIFF
--- a/src/components/set_lowering_stats_modal.js
+++ b/src/components/set_lowering_stats_modal.js
@@ -305,6 +305,7 @@ class SetLoweringStatsModal extends Component {
 
     this.props.handleUpdateLowering(newLoweringRecord)
     this.setState({touched: false})
+    this.props.handleHide()
   }
 
   setMilestoneToEdit(milestone = null) {


### PR DESCRIPTION
Default behavior is to clear the active dive upon submitting the dive editing form. If a modal remains open after hitting update, then the active dive is cleared, but you can make a change and hit update again which is interpreted as a new dive. 

Alternative solution is to simply not clear the active dive every time an update is pushed. We would want to update all other entity forms to behave the same way to remain consistent if we prefer that path.