### PR TITLE
Better route handling

### DIFF
--- a/config/client_config.js.dist
+++ b/config/client_config.js.dist
@@ -1,8 +1,10 @@
 window.client_config = {
 
-    // Use https:// and wss:// for secure servers
-    API_ROOT_URL:  `http://${window.location.hostname}:8000/sealog-server`,
-    WS_ROOT_URL:  `ws://${window.location.hostname}:8000/ws`,
+    // API URLs - use relative paths in development (proxied by dev server)
+    // In production, nginx proxies these paths to the backend
+    // For development with backend on different port, use: `http://${window.location.hostname}:8000/sealog-server`
+    API_ROOT_URL:  `${window.location.protocol}//${window.location.host}/sealog-server`,
+    WS_ROOT_URL:  `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`,
 
     // Derive the path at which Sealog is being hosted. This assumes that the
     // current executing script is ROOT_PATH/config/client_config.js

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -67,7 +67,8 @@ import {
   CREATE_LOWERING_SUCCESS,
   CREATE_LOWERING_ERROR,
   LEAVE_CREATE_LOWERING_FORM,
-  FETCH_LOWERINGS
+  FETCH_LOWERINGS,
+  SET_REDIRECT_PATH
 
 } from './types';
 
@@ -958,11 +959,19 @@ export function deleteEventTemplate(id) {
   };
 }
 
+export function setRedirectPath(path = null) {
+  return function(dispatch) {
+    return dispatch({ type: SET_REDIRECT_PATH, payload: path });
+  };
+}
+
 export function logout(redirectPath = null) {
   return function(dispatch) {
     // Save the path to redirect to after login (if provided and not /login or /logout)
     if (redirectPath && redirectPath !== '/login' && redirectPath !== '/logout') {
-      localStorage.setItem('redirectAfterLogin', redirectPath);
+      dispatch({ type: SET_REDIRECT_PATH, payload: redirectPath });
+    } else {
+      dispatch({ type: SET_REDIRECT_PATH, payload: null });
     }
 
     cookies.remove('token', { path: '/' });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -958,8 +958,13 @@ export function deleteEventTemplate(id) {
   };
 }
 
-export function logout() {
+export function logout(redirectPath = null) {
   return function(dispatch) {
+    // Save the path to redirect to after login (if provided and not /login or /logout)
+    if (redirectPath && redirectPath !== '/login' && redirectPath !== '/logout') {
+      localStorage.setItem('redirectAfterLogin', redirectPath);
+    }
+
     cookies.remove('token', { path: '/' });
     cookies.remove('id', { path: '/' });
     dispatch(push("/login"));

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -2,6 +2,7 @@ export const AUTH_USER = 'auth_user';
 export const UNAUTH_USER = 'unauth_user';
 export const AUTH_ERROR = 'auth_error';
 export const AUTH_SUCCESS = 'auth_success';
+export const SET_REDIRECT_PATH = 'set_redirect_path';
 
 export const LEAVE_AUTH_LOGIN_FORM = 'leave_auth_login_form';
 export const REFRESH_AUTH_LOGIN_FORM = 'refresh_auth_login_form';

--- a/src/api.js
+++ b/src/api.js
@@ -18,17 +18,28 @@ const cookies = new Cookies();
 //
 // axios.defaults.headers.common['Authorization'] = cookies.get('token');
 
+// Helper function to get authorization headers only when token exists
+function getAuthHeaders() {
+  const token = cookies.get('token');
+  return token ? { headers: { 'authorization': token } } : {};
+}
 
 export function getCruiseByLowering(id) {
   const url = `${API_ROOT_URL}/api/v1/cruises/bylowering/${id}`;
-  return axios.get(url, { headers: { 'authorization': cookies.get('token') } })
-    .catch((e) => console.error(e))
-    .then((r) => r.data);
+  return axios.get(url, getAuthHeaders())
+    .then((r) => r.data)
+    .catch((e) => {
+      console.error(e);
+      return null;
+    });
 }
 
 export function getLowering(id) {
   const url = `${API_ROOT_URL}/api/v1/lowerings/${id}`;
-  return axios.get(url, { headers: { 'authorization': cookies.get('token') } })
-    .catch((e) => console.error(e))
-    .then((r) => r.data);
+  return axios.get(url, getAuthHeaders())
+    .then((r) => r.data)
+    .catch((e) => {
+      console.error(e);
+      return null;
+    });
 }

--- a/src/api.js
+++ b/src/api.js
@@ -18,7 +18,6 @@ const cookies = new Cookies();
 //
 // axios.defaults.headers.common['Authorization'] = cookies.get('token');
 
-// Helper function to get authorization headers only when token exists
 function getAuthHeaders() {
   const token = cookies.get('token');
   return token ? { headers: { 'authorization': token } } : {};

--- a/src/components/auth/require_auth.js
+++ b/src/components/auth/require_auth.js
@@ -12,14 +12,16 @@ export default function(ComposedComponent) {
     componentDidMount() {
       this.props.validateJWT();
       if (!this.props.authenticated) {
-        this.props.logout()
+        // Pass current path so user can be redirected back after login
+        this.props.logout(window.location.pathname);
       }
     }
 
     componentDidUpdate() {
       this.props.validateJWT();
       if (!this.props.authenticated) {
-        this.props.logout();
+        // Pass current path so user can be redirected back after login
+        this.props.logout(window.location.pathname);
       }
     }
 

--- a/src/components/auth/require_unauth.js
+++ b/src/components/auth/require_unauth.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { push } from 'connected-react-router';
 import * as mapDispatchToProps from '../../actions';
+import { setRedirectPath } from '../../actions';
 
 export default function(ComposedComponent) {
   class Unauthentication extends Component {
@@ -28,10 +29,9 @@ export default function(ComposedComponent) {
     }
 
     handleRedirect() {
-      // Check if there's a saved redirect path from before login
-      const redirectPath = localStorage.getItem('redirectAfterLogin');
+      const redirectPath = this.props.redirectPath;
       if (redirectPath) {
-        localStorage.removeItem('redirectAfterLogin');
+        this.props.setRedirectPath(null);
         this.props.push(redirectPath);
       } else {
         this.props.gotoHome();
@@ -44,8 +44,11 @@ export default function(ComposedComponent) {
   }
 
   function mapStateToProps(state) {
-    return { authenticated: state.auth.authenticated };
+    return {
+      authenticated: state.auth.authenticated,
+      redirectPath: state.auth.redirectPath
+    };
   }
 
-  return connect(mapStateToProps, { ...mapDispatchToProps, push })(Unauthentication);
+  return connect(mapStateToProps, { ...mapDispatchToProps, push, setRedirectPath })(Unauthentication);
 }

--- a/src/components/auth/require_unauth.js
+++ b/src/components/auth/require_unauth.js
@@ -1,22 +1,39 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { push } from 'connected-react-router';
 import * as mapDispatchToProps from '../../actions';
 
 export default function(ComposedComponent) {
   class Unauthentication extends Component {
+    constructor(props) {
+      super(props);
+      this.handleRedirect = this.handleRedirect.bind(this);
+    }
+
     static contextTypes = {
       router: PropTypes.object
     }
 
     componentDidMount() {
       if (this.props.authenticated) {
-        this.props.gotoHome();
+        this.handleRedirect();
       }
     }
 
     componentDidUpdate() {
       if (this.props.authenticated) {
+        this.handleRedirect();
+      }
+    }
+
+    handleRedirect() {
+      // Check if there's a saved redirect path from before login
+      const redirectPath = localStorage.getItem('redirectAfterLogin');
+      if (redirectPath) {
+        localStorage.removeItem('redirectAfterLogin');
+        this.props.push(redirectPath);
+      } else {
         this.props.gotoHome();
       }
     }
@@ -30,5 +47,5 @@ export default function(ComposedComponent) {
     return { authenticated: state.auth.authenticated };
   }
 
-  return connect(mapStateToProps, mapDispatchToProps)(Unauthentication);
+  return connect(mapStateToProps, { ...mapDispatchToProps, push })(Unauthentication);
 }

--- a/src/components/event_history.js
+++ b/src/components/event_history.js
@@ -128,8 +128,9 @@ class EventHistory extends Component {
       this.client.subscribe('/ws/status/updateEventAuxData', updateAuxDataHandler);
 
     } catch(error) {
-      console.log(error);
-      throw(error);
+      // Silently handle WebSocket connection errors to avoid console spam
+      // The client will attempt to reconnect automatically
+      console.error('WebSocket connection error:', error.message);
     }
   }
 

--- a/src/components/event_template_list.js
+++ b/src/components/event_template_list.js
@@ -57,8 +57,9 @@ class EventTemplateList extends Component {
       this.client.subscribe('/ws/status/deleteEventTemplates', deleteHandler);
 
     } catch(error) {
-      console.log(error);
-      throw(error);
+      // Silently handle WebSocket connection errors to avoid console spam
+      // The client will attempt to reconnect automatically
+      console.error('WebSocket connection error:', error.message);
     }
   }
 

--- a/src/reducers/auth_reducer.js
+++ b/src/reducers/auth_reducer.js
@@ -4,10 +4,11 @@ import {
   AUTH_ERROR,
   AUTH_SUCCESS,
   LEAVE_AUTH_LOGIN_FORM,
-  REFRESH_AUTH_LOGIN_FORM
+  REFRESH_AUTH_LOGIN_FORM,
+  SET_REDIRECT_PATH
 } from '../actions/types';
 
-export default function( state={ error: '', message: '', authenticated: false }, action) {
+export default function( state={ error: '', message: '', authenticated: false, redirectPath: null }, action) {
   switch(action.type){
     case AUTH_USER:
       return { ...state, error: '', message: '', authenticated: true };
@@ -26,6 +27,9 @@ export default function( state={ error: '', message: '', authenticated: false },
 
     case LEAVE_AUTH_LOGIN_FORM:
       return { ...state, error: '', message: '' };
+
+    case SET_REDIRECT_PATH:
+      return { ...state, redirectPath: action.payload };
 
   }
   return state;

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -7,7 +7,6 @@ module.exports = function(app) {
     createProxyMiddleware({
       target: 'http://localhost:8000',
       changeOrigin: true,
-      // Keep cookies and authentication headers
       onProxyReq: (proxyReq, req, res) => {
         // Forward cookies from the browser
         if (req.headers.cookie) {

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,29 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  // Proxy API requests to the backend server
+  app.use(
+    '/sealog-server',
+    createProxyMiddleware({
+      target: 'http://localhost:8000',
+      changeOrigin: true,
+      // Keep cookies and authentication headers
+      onProxyReq: (proxyReq, req, res) => {
+        // Forward cookies from the browser
+        if (req.headers.cookie) {
+          proxyReq.setHeader('cookie', req.headers.cookie);
+        }
+      },
+    })
+  );
+
+  // Proxy WebSocket connections
+  app.use(
+    '/ws',
+    createProxyMiddleware({
+      target: 'ws://localhost:8000',
+      changeOrigin: true,
+      ws: true, // Enable WebSocket proxying
+    })
+  );
+};


### PR DESCRIPTION
If you open a new tab and go directly to a route like [0] you will be met with a blank screen, even if you're already authenticated. This is primarily because we keep trying to authenticate with `authorization` headers even when no token can be found; the cookie version of the token is httpOnly and inaccessible to JavaScript. 

This fixes that, and a couple more items:

- Adds a proxy to the development server to allow dev users to mimic the single-host experience of deployment; i.e. letting cookies pass through to the API server.
- Fixes some misc error handling bugs.
- Remembers the original route a user wanted if they get redirected to login.

[0] https://seaplay.whoi.edu/sealog-alvin/lowering_replay/63a8f5aa137dbe001a1f32e8