### PR TITLE
[codex] Handle empty replay event results

### DIFF
--- a/src/components/lowering_replay.js
+++ b/src/components/lowering_replay.js
@@ -378,7 +378,7 @@ class LoweringReplay extends Component {
             railStyle={{ opacity: 0.5 }}
             onBeforeChange={this.handleLoweringReplayPause}
             onChange={this.handleSliderChange}
-            max={this.props.event.events.length-1}
+            max={Math.max(this.props.event.events.length-1, 0)}
           />
         </div>
       </Card>

--- a/src/reducers/event_reducer.js
+++ b/src/reducers/event_reducer.js
@@ -15,7 +15,7 @@ export default function( state={ selected_event: {}, events: [], eventFilter: {}
   switch(action.type){
 
     case INIT_EVENT:
-      return { ...state, events: action.payload, selected_event: action.payload[0] };
+      return { ...state, events: action.payload, selected_event: action.payload[0] || {} };
 
     case UPDATE_EVENT:
       let newEvents = state.events.map((event) => {


### PR DESCRIPTION
## Summary

- Keep replay state stable when the initial event payload is empty.
- Prevent the replay slider from receiving a negative max value for zero-event result sets.

## Why

With the server returning `200 []` for an existing lowering with no matching events, the client still needs to render the replay controls cleanly so users can toggle ASNAP or adjust filters. This is necessary for older replays that mark every event as ASNAP, e.g. https://seaplay.whoi.edu/sealog-alvin/lowering_replay/Alvin-D3570