### PR TITLE
[codex] Auto-show ASNAP for ASNAP-only replays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -996,21 +996,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -5065,32 +5050,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
-    "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-import-attributes": "^7.24.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/babel-preset-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
@@ -5102,6 +5061,29 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest/node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -10441,6 +10423,29 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
@@ -18475,14 +18480,6 @@
         "@babel/helper-plugin-utils": "^7.19.0"
       }
     },
-    "@babel/plugin-syntax-import-attributes": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-      }
-    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -21199,35 +21196,34 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
-    "babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
-      "requires": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-import-attributes": "^7.24.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      }
-    },
     "babel-preset-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
       "integrity": "sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==",
       "requires": {
         "babel-plugin-jest-hoist": "^27.5.1",
-        "babel-preset-current-node-syntax": "^1.0.0"
+        "babel-preset-current-node-syntax": "1.0.1"
+      },
+      "dependencies": {
+        "babel-preset-current-node-syntax": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+          "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+          "requires": {
+            "@babel/plugin-syntax-async-generators": "^7.8.4",
+            "@babel/plugin-syntax-bigint": "^7.8.3",
+            "@babel/plugin-syntax-class-properties": "^7.8.3",
+            "@babel/plugin-syntax-import-meta": "^7.8.3",
+            "@babel/plugin-syntax-json-strings": "^7.8.3",
+            "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+            "@babel/plugin-syntax-top-level-await": "^7.8.3"
+          }
+        }
       }
     },
     "babel-preset-react-app": {
@@ -24757,7 +24753,7 @@
         "@jest/types": "^27.5.1",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
-        "babel-preset-current-node-syntax": "^1.0.0",
+        "babel-preset-current-node-syntax": "1.0.1",
         "chalk": "^4.0.0",
         "expect": "^27.5.1",
         "graceful-fs": "^4.2.9",
@@ -24772,6 +24768,25 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
+        "babel-preset-current-node-syntax": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+          "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+          "requires": {
+            "@babel/plugin-syntax-async-generators": "^7.8.4",
+            "@babel/plugin-syntax-bigint": "^7.8.3",
+            "@babel/plugin-syntax-class-properties": "^7.8.3",
+            "@babel/plugin-syntax-import-meta": "^7.8.3",
+            "@babel/plugin-syntax-json-strings": "^7.8.3",
+            "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+            "@babel/plugin-syntax-top-level-await": "^7.8.3"
+          }
+        },
         "semver": {
           "version": "7.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
       "react-app/jest"
     ]
   },
+  "overrides": {
+    "babel-preset-current-node-syntax": "1.0.1"
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,11 +81,12 @@ export const authorizationHeader = {
   }
 }
 
-async function fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP = true) {
-  const response = await axios.get(url, { headers: { authorization: cookies.get('token') } });
+async function fetchEventsWithASNAPFallback(url, hideASNAP, showASNAPAnywayIfEmpty = true) {
+  const hiddenASNAPUrl = hideASNAP ? `${url}&value=!ASNAP` : url;
+  const response = await axios.get(hiddenASNAPUrl, { headers: { authorization: cookies.get('token') } });
 
-  if(autoShowASNAP && hideASNAP && response.data.length === 0) {
-    const showASNAPResponse = await axios.get(showASNAPUrl, { headers: { authorization: cookies.get('token') } });
+  if(showASNAPAnywayIfEmpty && hideASNAP && response.data.length === 0) {
+    const showASNAPResponse = await axios.get(url, { headers: { authorization: cookies.get('token') } });
 
     if(showASNAPResponse.data.length > 0) {
       return { events: showASNAPResponse.data, showASNAP: true };
@@ -1483,12 +1484,9 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
-    const url = (hideASNAP)
-      ? `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?value=!ASNAP`
-      : `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
-    const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
+    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?`;
 
-    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP)
+    return await fetchEventsWithASNAPFallback(url, hideASNAP)
     .then((response) => {
       if(response.showASNAP) {
         dispatch({ type: SHOW_ASNAP });
@@ -1659,22 +1657,20 @@ export function eventUpdate() {
   };
 }
 
-export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, autoShowASNAP = true) {
+export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, showASNAPAnywayIfEmpty = true) {
   return async function (dispatch, getState) {
 
     let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
     let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
     let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
-    let hiddenASNAPValue = (hideASNAP)? `&value=!ASNAP${value}` : value;
     let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
     let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
     let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
     let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
-    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${hiddenASNAPValue}${author}${freetext}${fulltext}${datasource}`;
-    const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`;
+    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`;
 
     dispatch({ type: EVENT_FETCHING, payload: true});
-    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP)
+    return await fetchEventsWithASNAPFallback(url, hideASNAP, showASNAPAnywayIfEmpty)
     .then((response) => {
       if(response.showASNAP) {
         dispatch({ type: SHOW_ASNAP });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -82,11 +82,16 @@ export const authorizationHeader = {
 }
 
 async function fetchEventsWithASNAPFallback(url, hideASNAP, showASNAPAnywayIfEmpty = true) {
-  const hiddenASNAPUrl = hideASNAP ? `${url}&value=!ASNAP` : url;
-  const response = await axios.get(hiddenASNAPUrl, { headers: { authorization: cookies.get('token') } });
+  const showASNAPUrl = url.toString();
+
+  if(hideASNAP) {
+    url.searchParams.append('value', '!ASNAP');
+  }
+
+  const response = await axios.get(url.toString(), { headers: { authorization: cookies.get('token') } });
 
   if(showASNAPAnywayIfEmpty && hideASNAP && response.data.length === 0) {
-    const showASNAPResponse = await axios.get(url, { headers: { authorization: cookies.get('token') } });
+    const showASNAPResponse = await axios.get(showASNAPUrl, { headers: { authorization: cookies.get('token') } });
 
     if(showASNAPResponse.data.length > 0) {
       return { events: showASNAPResponse.data, showASNAP: true };
@@ -1484,7 +1489,7 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
-    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?`;
+    const url = new URL(`${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`);
 
     return await fetchEventsWithASNAPFallback(url, hideASNAP)
     .then((response) => {
@@ -1660,14 +1665,40 @@ export function eventUpdate() {
 export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, showASNAPAnywayIfEmpty = true) {
   return async function (dispatch, getState) {
 
-    let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
-    let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
-    let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
-    let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
-    let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
-    let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
-    let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
-    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`;
+    const eventFilter = getState().event.eventFilter;
+    const url = new URL(`${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}`);
+
+    if(eventFilter.startTS) {
+      url.searchParams.set('startTS', eventFilter.startTS);
+    }
+
+    if(eventFilter.stopTS) {
+      url.searchParams.set('stopTS', eventFilter.stopTS);
+    }
+
+    if(eventFilter.value) {
+      eventFilter.value.split(',').forEach((value) => {
+        url.searchParams.append('value', value);
+      });
+    }
+
+    if(eventFilter.author) {
+      eventFilter.author.split(',').forEach((author) => {
+        url.searchParams.append('author', author);
+      });
+    }
+
+    if(eventFilter.freetext) {
+      url.searchParams.set('freetext', eventFilter.freetext);
+    }
+
+    if(eventFilter.fulltext) {
+      url.searchParams.set('fulltext', eventFilter.fulltext);
+    }
+
+    if(eventFilter.datasource) {
+      url.searchParams.set('datasource', eventFilter.datasource);
+    }
 
     dispatch({ type: EVENT_FETCHING, payload: true});
     return await fetchEventsWithASNAPFallback(url, hideASNAP, showASNAPAnywayIfEmpty)

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,67 +81,6 @@ export const authorizationHeader = {
   }
 }
 
-function buildLoweringEventQuery(eventFilter = {}, hideASNAP = false) {
-  const params = new URLSearchParams();
-
-  if(eventFilter.startTS) {
-    params.append('startTS', eventFilter.startTS);
-  }
-
-  if(eventFilter.stopTS) {
-    params.append('stopTS', eventFilter.stopTS);
-  }
-
-  if(hideASNAP) {
-    params.append('value', '!ASNAP');
-  }
-
-  if(eventFilter.value) {
-    eventFilter.value.split(',').forEach((value) => {
-      params.append('value', value);
-    });
-  }
-
-  if(eventFilter.author) {
-    eventFilter.author.split(',').forEach((author) => {
-      params.append('author', author);
-    });
-  }
-
-  if(eventFilter.freetext) {
-    params.append('freetext', eventFilter.freetext);
-  }
-
-  if(eventFilter.fulltext) {
-    params.append('fulltext', eventFilter.fulltext);
-  }
-
-  if(eventFilter.datasource) {
-    params.append('datasource', eventFilter.datasource);
-  }
-
-  const query = params.toString();
-  return query ? `?${query}` : '';
-}
-
-function buildLoweringEventsUrl(lowering_id, eventFilter = {}, hideASNAP = false) {
-  return `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}${buildLoweringEventQuery(eventFilter, hideASNAP)}`;
-}
-
-async function fetchLoweringEventsWithASNAPFallback(lowering_id, eventFilter = {}, hideASNAP = false, autoShowASNAP = true) {
-  const response = await axios.get(buildLoweringEventsUrl(lowering_id, eventFilter, hideASNAP), { headers: { authorization: cookies.get('token') } });
-
-  if(autoShowASNAP && hideASNAP && response.data.length === 0) {
-    const showASNAPResponse = await axios.get(buildLoweringEventsUrl(lowering_id, eventFilter, false), { headers: { authorization: cookies.get('token') } });
-
-    if(showASNAPResponse.data.length > 0) {
-      return { events: showASNAPResponse.data, showASNAP: true };
-    }
-  }
-
-  return { events: response.data, showASNAP: false };
-}
-
 export function validateJWT() {
 
   const token = cookies.get('token');
@@ -1530,19 +1469,19 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
-    return await fetchLoweringEventsWithASNAPFallback(databaseId, {}, hideASNAP)
-    .then((response) => {
-      if(response.showASNAP) {
-        dispatch({ type: SHOW_ASNAP });
-      }
+    let url = (hideASNAP)
+      ? `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?value=!ASNAP`
+      : `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
 
-      dispatch({ type: INIT_EVENT, payload: response.events });
-      if (response.events.length > 0){
-        dispatch(advanceLoweringReplayTo(response.events[0].id));
+    return await axios.get(url, { headers: { authorization: cookies.get('token') } }
+    ).then((response) => {
+      dispatch({ type: INIT_EVENT, payload: response.data });
+      if (response.data.length > 0){
+        dispatch(advanceLoweringReplayTo(response.data[0].id));
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
     }).catch((error)=>{
-      if(error.response?.data?.statusCode !== 404) {
+      if(error.response.data.statusCode !== 404) {
         console.error(error);
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
@@ -1701,25 +1640,28 @@ export function eventUpdate() {
   };
 }
 
-export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, autoShowASNAP = true) {
+export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false) {
   return async function (dispatch, getState) {
 
-    dispatch({ type: EVENT_FETCHING, payload: true});
-    return await fetchLoweringEventsWithASNAPFallback(lowering_id, getState().event.eventFilter, hideASNAP, autoShowASNAP)
-    .then((response) => {
-      if(response.showASNAP) {
-        dispatch({ type: SHOW_ASNAP });
-      }
+    let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
+    let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
+    let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
+    value = (hideASNAP)? `&value=!ASNAP${value}` : value;
+    let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
+    let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
+    let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
+    let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
 
-      dispatch({ type: UPDATE_EVENTS, payload: response.events });
-      if(response.events.length > 0) {
-        dispatch(fetchSelectedEvent(response.events[0].id));
-      } else {
-        dispatch({ type: SET_SELECTED_EVENT, payload: {} });
+    dispatch({ type: EVENT_FETCHING, payload: true});
+    return await axios.get(`${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`, { headers: { authorization: cookies.get('token') } }
+    ).then((response) => {
+      dispatch({ type: UPDATE_EVENTS, payload: response.data });
+      if(response.data.length > 0) {
+        dispatch(fetchSelectedEvent(response.data[0].id));
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
     }).catch((error)=>{
-      if(error.response?.data?.statusCode === 404) {
+      if(error.response.data.statusCode === 404) {
         dispatch({type: UPDATE_EVENTS, payload: []});
         dispatch({ type: SET_SELECTED_EVENT, payload: {} });
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,6 +81,20 @@ export const authorizationHeader = {
   }
 }
 
+async function fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP = true) {
+  const response = await axios.get(url, { headers: { authorization: cookies.get('token') } });
+
+  if(autoShowASNAP && hideASNAP && response.data.length === 0) {
+    const showASNAPResponse = await axios.get(showASNAPUrl, { headers: { authorization: cookies.get('token') } });
+
+    if(showASNAPResponse.data.length > 0) {
+      return { events: showASNAPResponse.data, showASNAP: true };
+    }
+  }
+
+  return { events: response.data, showASNAP: false };
+}
+
 export function validateJWT() {
 
   const token = cookies.get('token');
@@ -1469,15 +1483,20 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
-    let url = (hideASNAP)
+    const url = (hideASNAP)
       ? `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?value=!ASNAP`
       : `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
+    const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
 
-    return await axios.get(url, { headers: { authorization: cookies.get('token') } }
-    ).then((response) => {
-      dispatch({ type: INIT_EVENT, payload: response.data });
-      if (response.data.length > 0){
-        dispatch(advanceLoweringReplayTo(response.data[0].id));
+    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP)
+    .then((response) => {
+      if(response.showASNAP) {
+        dispatch({ type: SHOW_ASNAP });
+      }
+
+      dispatch({ type: INIT_EVENT, payload: response.events });
+      if (response.events.length > 0){
+        dispatch(advanceLoweringReplayTo(response.events[0].id));
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
     }).catch((error)=>{
@@ -1640,24 +1659,30 @@ export function eventUpdate() {
   };
 }
 
-export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false) {
+export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, autoShowASNAP = true) {
   return async function (dispatch, getState) {
 
     let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
     let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
     let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
-    value = (hideASNAP)? `&value=!ASNAP${value}` : value;
+    let hiddenASNAPValue = (hideASNAP)? `&value=!ASNAP${value}` : value;
     let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
     let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
     let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
     let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
+    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${hiddenASNAPValue}${author}${freetext}${fulltext}${datasource}`;
+    const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`;
 
     dispatch({ type: EVENT_FETCHING, payload: true});
-    return await axios.get(`${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`, { headers: { authorization: cookies.get('token') } }
-    ).then((response) => {
-      dispatch({ type: UPDATE_EVENTS, payload: response.data });
-      if(response.data.length > 0) {
-        dispatch(fetchSelectedEvent(response.data[0].id));
+    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP)
+    .then((response) => {
+      if(response.showASNAP) {
+        dispatch({ type: SHOW_ASNAP });
+      }
+
+      dispatch({ type: UPDATE_EVENTS, payload: response.events });
+      if(response.events.length > 0) {
+        dispatch(fetchSelectedEvent(response.events[0].id));
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
     }).catch((error)=>{

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,10 +81,19 @@ export const authorizationHeader = {
   }
 }
 
-async function fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP = true) {
+function appendQueryParam(url, param) {
+  if(url.endsWith('?') || url.endsWith('&')) {
+    return `${url}${param}`;
+  }
+
+  return `${url}${url.includes('?') ? '&' : '?'}${param}`;
+}
+
+async function fetchEventsWithASNAPFallback(showASNAPUrl, hideASNAP, showASNAPAnywayIfEmpty = true) {
+  const url = hideASNAP ? appendQueryParam(showASNAPUrl, 'value=!ASNAP') : showASNAPUrl;
   const response = await axios.get(url, { headers: { authorization: cookies.get('token') } });
 
-  if(autoShowASNAP && hideASNAP && response.data.length === 0) {
+  if(showASNAPAnywayIfEmpty && hideASNAP && response.data.length === 0) {
     const showASNAPResponse = await axios.get(showASNAPUrl, { headers: { authorization: cookies.get('token') } });
 
     if(showASNAPResponse.data.length > 0) {
@@ -1483,12 +1492,9 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
-    const url = (hideASNAP)
-      ? `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?value=!ASNAP`
-      : `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
     const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
 
-    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP)
+    return await fetchEventsWithASNAPFallback(showASNAPUrl, hideASNAP)
     .then((response) => {
       if(response.showASNAP) {
         dispatch({ type: SHOW_ASNAP });
@@ -1659,22 +1665,20 @@ export function eventUpdate() {
   };
 }
 
-export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, autoShowASNAP = true) {
+export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, showASNAPAnywayIfEmpty = true) {
   return async function (dispatch, getState) {
 
     let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
     let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
     let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
-    let hiddenASNAPValue = (hideASNAP)? `&value=!ASNAP${value}` : value;
     let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
     let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
     let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
     let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
-    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${hiddenASNAPValue}${author}${freetext}${fulltext}${datasource}`;
     const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`;
 
     dispatch({ type: EVENT_FETCHING, payload: true});
-    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP)
+    return await fetchEventsWithASNAPFallback(showASNAPUrl, hideASNAP, showASNAPAnywayIfEmpty)
     .then((response) => {
       if(response.showASNAP) {
         dispatch({ type: SHOW_ASNAP });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,6 +81,67 @@ export const authorizationHeader = {
   }
 }
 
+function buildLoweringEventQuery(eventFilter = {}, hideASNAP = false) {
+  const params = new URLSearchParams();
+
+  if(eventFilter.startTS) {
+    params.append('startTS', eventFilter.startTS);
+  }
+
+  if(eventFilter.stopTS) {
+    params.append('stopTS', eventFilter.stopTS);
+  }
+
+  if(hideASNAP) {
+    params.append('value', '!ASNAP');
+  }
+
+  if(eventFilter.value) {
+    eventFilter.value.split(',').forEach((value) => {
+      params.append('value', value);
+    });
+  }
+
+  if(eventFilter.author) {
+    eventFilter.author.split(',').forEach((author) => {
+      params.append('author', author);
+    });
+  }
+
+  if(eventFilter.freetext) {
+    params.append('freetext', eventFilter.freetext);
+  }
+
+  if(eventFilter.fulltext) {
+    params.append('fulltext', eventFilter.fulltext);
+  }
+
+  if(eventFilter.datasource) {
+    params.append('datasource', eventFilter.datasource);
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+function buildLoweringEventsUrl(lowering_id, eventFilter = {}, hideASNAP = false) {
+  return `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}${buildLoweringEventQuery(eventFilter, hideASNAP)}`;
+}
+
+async function fetchLoweringEventsWithASNAPFallback(lowering_id, eventFilter = {}, hideASNAP = false, autoShowASNAP = true) {
+  const response = await axios.get(buildLoweringEventsUrl(lowering_id, eventFilter, hideASNAP), { headers: { authorization: cookies.get('token') } });
+
+  if(autoShowASNAP && hideASNAP && response.data.length === 0) {
+    const showASNAPResponse = await axios.get(buildLoweringEventsUrl(lowering_id, eventFilter, false), { headers: { authorization: cookies.get('token') } });
+
+    if(showASNAPResponse.data.length > 0) {
+      return { events: showASNAPResponse.data, showASNAP: true };
+    }
+  }
+
+  return { events: response.data, showASNAP: false };
+}
+
 export function validateJWT() {
 
   const token = cookies.get('token');
@@ -1469,19 +1530,19 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
-    let url = (hideASNAP)
-      ? `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?value=!ASNAP`
-      : `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
+    return await fetchLoweringEventsWithASNAPFallback(databaseId, {}, hideASNAP)
+    .then((response) => {
+      if(response.showASNAP) {
+        dispatch({ type: SHOW_ASNAP });
+      }
 
-    return await axios.get(url, { headers: { authorization: cookies.get('token') } }
-    ).then((response) => {
-      dispatch({ type: INIT_EVENT, payload: response.data });
-      if (response.data.length > 0){
-        dispatch(advanceLoweringReplayTo(response.data[0].id));
+      dispatch({ type: INIT_EVENT, payload: response.events });
+      if (response.events.length > 0){
+        dispatch(advanceLoweringReplayTo(response.events[0].id));
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
     }).catch((error)=>{
-      if(error.response.data.statusCode !== 404) {
+      if(error.response?.data?.statusCode !== 404) {
         console.error(error);
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
@@ -1640,28 +1701,25 @@ export function eventUpdate() {
   };
 }
 
-export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false) {
+export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, autoShowASNAP = true) {
   return async function (dispatch, getState) {
 
-    let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
-    let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
-    let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
-    value = (hideASNAP)? `&value=!ASNAP${value}` : value;
-    let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
-    let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
-    let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
-    let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
-
     dispatch({ type: EVENT_FETCHING, payload: true});
-    return await axios.get(`${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`, { headers: { authorization: cookies.get('token') } }
-    ).then((response) => {
-      dispatch({ type: UPDATE_EVENTS, payload: response.data });
-      if(response.data.length > 0) {
-        dispatch(fetchSelectedEvent(response.data[0].id));
+    return await fetchLoweringEventsWithASNAPFallback(lowering_id, getState().event.eventFilter, hideASNAP, autoShowASNAP)
+    .then((response) => {
+      if(response.showASNAP) {
+        dispatch({ type: SHOW_ASNAP });
+      }
+
+      dispatch({ type: UPDATE_EVENTS, payload: response.events });
+      if(response.events.length > 0) {
+        dispatch(fetchSelectedEvent(response.events[0].id));
+      } else {
+        dispatch({ type: SET_SELECTED_EVENT, payload: {} });
       }
       return dispatch({ type: EVENT_FETCHING, payload: false});
     }).catch((error)=>{
-      if(error.response.data.statusCode === 404) {
+      if(error.response?.data?.statusCode === 404) {
         dispatch({type: UPDATE_EVENTS, payload: []});
         dispatch({ type: SET_SELECTED_EVENT, payload: {} });
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -81,19 +81,10 @@ export const authorizationHeader = {
   }
 }
 
-function appendQueryParam(url, param) {
-  if(url.endsWith('?') || url.endsWith('&')) {
-    return `${url}${param}`;
-  }
-
-  return `${url}${url.includes('?') ? '&' : '?'}${param}`;
-}
-
-async function fetchEventsWithASNAPFallback(showASNAPUrl, hideASNAP, showASNAPAnywayIfEmpty = true) {
-  const url = hideASNAP ? appendQueryParam(showASNAPUrl, 'value=!ASNAP') : showASNAPUrl;
+async function fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP = true) {
   const response = await axios.get(url, { headers: { authorization: cookies.get('token') } });
 
-  if(showASNAPAnywayIfEmpty && hideASNAP && response.data.length === 0) {
+  if(autoShowASNAP && hideASNAP && response.data.length === 0) {
     const showASNAPResponse = await axios.get(showASNAPUrl, { headers: { authorization: cookies.get('token') } });
 
     if(showASNAPResponse.data.length > 0) {
@@ -1492,9 +1483,12 @@ export function initLoweringReplay(id, hideASNAP = false) {
     // Use the database ID from the fetched lowering
     const databaseId = lowering.id;
 
+    const url = (hideASNAP)
+      ? `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}?value=!ASNAP`
+      : `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
     const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${databaseId}`;
 
-    return await fetchEventsWithASNAPFallback(showASNAPUrl, hideASNAP)
+    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP)
     .then((response) => {
       if(response.showASNAP) {
         dispatch({ type: SHOW_ASNAP });
@@ -1665,20 +1659,22 @@ export function eventUpdate() {
   };
 }
 
-export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, showASNAPAnywayIfEmpty = true) {
+export function eventUpdateLoweringReplay(lowering_id, hideASNAP = false, autoShowASNAP = true) {
   return async function (dispatch, getState) {
 
     let startTS = (getState().event.eventFilter.startTS)? `startTS=${getState().event.eventFilter.startTS}` : '';
     let stopTS = (getState().event.eventFilter.stopTS)? `&stopTS=${getState().event.eventFilter.stopTS}` : '';
     let value = (getState().event.eventFilter.value)? `&value=${getState().event.eventFilter.value.split(',').join("&value=")}` : '';
+    let hiddenASNAPValue = (hideASNAP)? `&value=!ASNAP${value}` : value;
     let author = (getState().event.eventFilter.author)? `&author=${getState().event.eventFilter.author.split(',').join("&author=")}` : '';
     let freetext = (getState().event.eventFilter.freetext)? `&freetext=${getState().event.eventFilter.freetext}` : '';
     let fulltext = (getState().event.eventFilter.fulltext)? `&fulltext=${getState().event.eventFilter.fulltext}` : '';
     let datasource = (getState().event.eventFilter.datasource)? `&datasource=${getState().event.eventFilter.datasource}` : '';
+    const url = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${hiddenASNAPValue}${author}${freetext}${fulltext}${datasource}`;
     const showASNAPUrl = `${API_ROOT_URL}/api/v1/events/bylowering/${lowering_id}?${startTS}${stopTS}${value}${author}${freetext}${fulltext}${datasource}`;
 
     dispatch({ type: EVENT_FETCHING, payload: true});
-    return await fetchEventsWithASNAPFallback(showASNAPUrl, hideASNAP, showASNAPAnywayIfEmpty)
+    return await fetchEventsWithASNAPFallback(url, showASNAPUrl, hideASNAP, autoShowASNAP)
     .then((response) => {
       if(response.showASNAP) {
         dispatch({ type: SHOW_ASNAP });

--- a/src/actions/lowering_replay.test.js
+++ b/src/actions/lowering_replay.test.js
@@ -134,7 +134,7 @@ describe('lowering replay actions', () => {
     await eventUpdateLoweringReplay('lowering-db-id', true)(dispatch, getState);
     await Promise.resolve();
 
-    expect(urlForCall(0).searchParams.getAll('value')).toEqual(['!ASNAP', 'BIOLOGY', 'SAMPLE']);
+    expect(urlForCall(0).searchParams.getAll('value')).toEqual(['BIOLOGY', 'SAMPLE', '!ASNAP']);
     expect(urlForCall(1).searchParams.getAll('value')).toEqual(['BIOLOGY', 'SAMPLE']);
     expect(urlForCall(1).searchParams.getAll('author')).toEqual(['alvin', 'bob']);
     expect(urlForCall(1).searchParams.get('freetext')).toBe('vent');
@@ -145,7 +145,7 @@ describe('lowering replay actions', () => {
     expect(actions).toContainEqual({ type: EVENT_FETCHING, payload: false });
   });
 
-  it('does not auto-show ASNAP when replay updates opt out of fallback', async () => {
+  it('does not show ASNAP anyway when replay updates opt out of fallback', async () => {
     axios.get.mockResolvedValueOnce({ data: [] });
 
     const { actions, dispatch, getState } = createThunkHarness();

--- a/src/actions/lowering_replay.test.js
+++ b/src/actions/lowering_replay.test.js
@@ -134,7 +134,7 @@ describe('lowering replay actions', () => {
     await eventUpdateLoweringReplay('lowering-db-id', true)(dispatch, getState);
     await Promise.resolve();
 
-    expect(urlForCall(0).searchParams.getAll('value')).toEqual(['BIOLOGY', 'SAMPLE', '!ASNAP']);
+    expect(urlForCall(0).searchParams.getAll('value')).toEqual(['!ASNAP', 'BIOLOGY', 'SAMPLE']);
     expect(urlForCall(1).searchParams.getAll('value')).toEqual(['BIOLOGY', 'SAMPLE']);
     expect(urlForCall(1).searchParams.getAll('author')).toEqual(['alvin', 'bob']);
     expect(urlForCall(1).searchParams.get('freetext')).toBe('vent');
@@ -145,7 +145,7 @@ describe('lowering replay actions', () => {
     expect(actions).toContainEqual({ type: EVENT_FETCHING, payload: false });
   });
 
-  it('does not show ASNAP anyway when replay updates opt out of fallback', async () => {
+  it('does not auto-show ASNAP when replay updates opt out of fallback', async () => {
     axios.get.mockResolvedValueOnce({ data: [] });
 
     const { actions, dispatch, getState } = createThunkHarness();

--- a/src/actions/lowering_replay.test.js
+++ b/src/actions/lowering_replay.test.js
@@ -1,0 +1,147 @@
+import axios from 'axios';
+import {
+  eventUpdateLoweringReplay,
+  initLoweringReplay
+} from './index';
+import {
+  EVENT_FETCHING,
+  INIT_CRUISE,
+  INIT_EVENT,
+  INIT_LOWERING,
+  SET_SELECTED_EVENT,
+  SHOW_ASNAP,
+  UPDATE_EVENTS
+} from './types';
+
+jest.mock('axios');
+jest.mock('client_config', () => ({
+  API_ROOT_URL: 'http://api.test/sealog-server'
+}));
+jest.mock('universal-cookie', () => jest.fn().mockImplementation(() => ({
+  get: () => 'test-token'
+})));
+
+const lowering = {
+  id: 'lowering-db-id',
+  lowering_id: 'Alvin-D2770',
+  start_ts: '2000-01-01T00:00:00.000Z',
+  stop_ts: '2000-01-01T01:00:00.000Z'
+};
+
+const cruise = {
+  id: 'cruise-db-id',
+  cruise_id: 'AT-test'
+};
+
+const asnapEvent = {
+  id: 'asnap-event-id',
+  event_value: 'ASNAP',
+  ts: '2000-01-01T00:15:00.000Z'
+};
+
+const selectedASNAPEvent = {
+  ...asnapEvent,
+  aux_data: []
+};
+
+function createThunkHarness(initialState = {}) {
+  let state = {
+    event: {
+      eventFilter: {}
+    },
+    lowering: {
+      lowering: null
+    },
+    ...initialState
+  };
+  const actions = [];
+
+  const getState = () => state;
+  const dispatch = jest.fn((action) => {
+    if(typeof action === 'function') {
+      return action(dispatch, getState);
+    }
+
+    actions.push(action);
+
+    if(action.type === INIT_LOWERING) {
+      state = {
+        ...state,
+        lowering: {
+          ...state.lowering,
+          lowering: action.payload
+        }
+      };
+    }
+
+    return action;
+  });
+
+  return { actions, dispatch, getState };
+}
+
+function urlForCall(callIndex) {
+  return new URL(axios.get.mock.calls[callIndex][0]);
+}
+
+describe('lowering replay actions', () => {
+  beforeEach(() => {
+    axios.get.mockReset();
+  });
+
+  it('auto-shows ASNAP on initial replay load when hidden-ASNAP results are empty but ASNAP events exist', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: lowering })
+      .mockResolvedValueOnce({ data: [cruise] })
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [asnapEvent] })
+      .mockResolvedValueOnce({ data: selectedASNAPEvent });
+
+    const { actions, dispatch, getState } = createThunkHarness();
+
+    await initLoweringReplay('Alvin-D2770', true)(dispatch, getState);
+    await Promise.resolve();
+
+    expect(urlForCall(2).pathname).toBe('/sealog-server/api/v1/events/bylowering/lowering-db-id');
+    expect(urlForCall(2).searchParams.getAll('value')).toEqual(['!ASNAP']);
+    expect(urlForCall(3).pathname).toBe('/sealog-server/api/v1/events/bylowering/lowering-db-id');
+    expect(urlForCall(3).searchParams.getAll('value')).toEqual([]);
+    expect(actions).toContainEqual({ type: SHOW_ASNAP });
+    expect(actions).toContainEqual({ type: INIT_EVENT, payload: [asnapEvent] });
+    expect(actions).toContainEqual({ type: SET_SELECTED_EVENT, payload: selectedASNAPEvent });
+  });
+
+  it('auto-shows ASNAP on replay filter updates while preserving user filters on the fallback request', async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [asnapEvent] })
+      .mockResolvedValueOnce({ data: selectedASNAPEvent });
+
+    const { actions, dispatch, getState } = createThunkHarness({
+      event: {
+        eventFilter: {
+          startTS: '2000-01-01T00:00:00.000Z',
+          stopTS: '2000-01-01T01:00:00.000Z',
+          value: 'BIOLOGY,SAMPLE',
+          author: 'alvin,bob',
+          freetext: 'vent',
+          fulltext: 'white smoker',
+          datasource: 'vehicleRealtimeNavData'
+        }
+      }
+    });
+
+    await eventUpdateLoweringReplay('lowering-db-id', true)(dispatch, getState);
+    await Promise.resolve();
+
+    expect(urlForCall(0).searchParams.getAll('value')).toEqual(['!ASNAP', 'BIOLOGY', 'SAMPLE']);
+    expect(urlForCall(1).searchParams.getAll('value')).toEqual(['BIOLOGY', 'SAMPLE']);
+    expect(urlForCall(1).searchParams.getAll('author')).toEqual(['alvin', 'bob']);
+    expect(urlForCall(1).searchParams.get('freetext')).toBe('vent');
+    expect(urlForCall(1).searchParams.get('fulltext')).toBe('white smoker');
+    expect(urlForCall(1).searchParams.get('datasource')).toBe('vehicleRealtimeNavData');
+    expect(actions).toContainEqual({ type: SHOW_ASNAP });
+    expect(actions).toContainEqual({ type: UPDATE_EVENTS, payload: [asnapEvent] });
+    expect(actions).toContainEqual({ type: EVENT_FETCHING, payload: false });
+  });
+});

--- a/src/actions/lowering_replay.test.js
+++ b/src/actions/lowering_replay.test.js
@@ -144,4 +144,17 @@ describe('lowering replay actions', () => {
     expect(actions).toContainEqual({ type: UPDATE_EVENTS, payload: [asnapEvent] });
     expect(actions).toContainEqual({ type: EVENT_FETCHING, payload: false });
   });
+
+  it('does not auto-show ASNAP when replay updates opt out of fallback', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    const { actions, dispatch, getState } = createThunkHarness();
+
+    await eventUpdateLoweringReplay('lowering-db-id', true, false)(dispatch, getState);
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(urlForCall(0).searchParams.getAll('value')).toEqual(['!ASNAP']);
+    expect(actions).not.toContainEqual({ type: SHOW_ASNAP });
+    expect(actions).toContainEqual({ type: UPDATE_EVENTS, payload: [] });
+  });
 });

--- a/src/components/lowering_gallery.js
+++ b/src/components/lowering_gallery.js
@@ -81,7 +81,7 @@ class LoweringGallery extends Component {
   }
 
   toggleASNAP() {
-    this.props.eventUpdateLoweringReplay(this.props.lowering.id, this.props.event.hideASNAP, false);
+    this.props.eventUpdateLoweringReplay(this.props.lowering.id, this.props.event.hideASNAP);
 
     if(this.props.event.hideASNAP) {
       this.props.showASNAP();

--- a/src/components/lowering_gallery.js
+++ b/src/components/lowering_gallery.js
@@ -81,7 +81,7 @@ class LoweringGallery extends Component {
   }
 
   toggleASNAP() {
-    this.props.eventUpdateLoweringReplay(this.props.lowering.id, this.props.event.hideASNAP);
+    this.props.eventUpdateLoweringReplay(this.props.lowering.id, this.props.event.hideASNAP, false);
 
     if(this.props.event.hideASNAP) {
       this.props.showASNAP();

--- a/src/components/lowering_map.js
+++ b/src/components/lowering_map.js
@@ -122,7 +122,7 @@ class LoweringMap extends Component {
   }
 
   toggleASNAP() {
-    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP, false);
+    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP);
     if(this.props.event.hideASNAP) {
       this.props.showASNAP();
       this.handleEventClick(0);

--- a/src/components/lowering_map.js
+++ b/src/components/lowering_map.js
@@ -122,7 +122,7 @@ class LoweringMap extends Component {
   }
 
   toggleASNAP() {
-    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP);
+    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP, false);
     if(this.props.event.hideASNAP) {
       this.props.showASNAP();
       this.handleEventClick(0);

--- a/src/components/lowering_replay.js
+++ b/src/components/lowering_replay.js
@@ -119,7 +119,7 @@ class LoweringReplay extends Component {
   }
 
   toggleASNAP() {
-    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP);
+    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP, false);
     this.handleLoweringReplayPause();
     if(this.props.event.hideASNAP) {
       this.props.showASNAP();

--- a/src/components/lowering_replay.js
+++ b/src/components/lowering_replay.js
@@ -119,7 +119,7 @@ class LoweringReplay extends Component {
   }
 
   toggleASNAP() {
-    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP, false);
+    this.props.eventUpdateLoweringReplay(this.props.lowering.id, !this.props.event.hideASNAP);
     this.handleLoweringReplayPause();
     if(this.props.event.hideASNAP) {
       this.props.showASNAP();


### PR DESCRIPTION
## Summary

- Roll back the original broader implementation, then add focused thunk tests for ASNAP-only replay behavior.
- Auto-show ASNAP in lowering replay/map flows when the hidden-ASNAP query is empty but the same query with ASNAP included has events.
- Keep manual ASNAP toggle clicks manual by opting those calls out with `showASNAPAnywayIfEmpty=false`.
- Simplify fallback URL handling so callers pass one ASNAP-visible URL and the helper appends `value=!ASNAP` internally for the hidden-ASNAP attempt.
- Pin Jest current-node syntax preset to avoid the import-attributes/Babel-core mismatch that prevented action tests from running under react-scripts.

## Validation

- `npm test -- --runInBand --watchAll=false src/actions/lowering_replay.test.js`
- `CI=false npm run build`
