### PR TITLE
Fix post-login redirect doubling the ROOT_PATH basename

### DIFF
--- a/src/components/auth/require_auth.js
+++ b/src/components/auth/require_auth.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import * as mapDispatchToProps from '../../actions';
+import history from '../../history';
 
 export default function(ComposedComponent) {
   class Authentication extends Component {
@@ -13,7 +14,7 @@ export default function(ComposedComponent) {
       this.props.validateJWT();
       if (!this.props.authenticated) {
         // Pass current path so user can be redirected back after login
-        this.props.logout(window.location.pathname);
+        this.props.logout(history.location.pathname);
       }
     }
 
@@ -21,7 +22,7 @@ export default function(ComposedComponent) {
       this.props.validateJWT();
       if (!this.props.authenticated) {
         // Pass current path so user can be redirected back after login
-        this.props.logout(window.location.pathname);
+        this.props.logout(history.location.pathname);
       }
     }
 


### PR DESCRIPTION
## Problem

Logging in (e.g. **Login as Port Observer**) from a fresh session lands on a blank page — only the header and `ASNAP: Unknown` footer render.

The URL ends up at `…/sealog/sealog/` (the `/sealog` basename appears **twice**), which matches no `<Route>`, so the `<Switch>` renders nothing.

## Root cause

`RequireAuth` captures the return-to path with `window.location.pathname`, which is the **raw browser path including the `ROOT_PATH` basename** (`/sealog/`). That value is stored as `redirectPath` and later replayed by `RequireUnauth` via `push(redirectPath)`. Because the router's history is created with `basename: ROOT_PATH`, `push()` prepends the basename **again** → `/sealog/sealog/`.

`window.location.pathname` and `history.push()` are in two different coordinate systems; the redirect machinery mixed them.

## Fix

Capture the **basename-relative** path via the app's own `history` singleton (`history.location.pathname`) instead of `window.location.pathname`. The same `ROOT_PATH` parameterizes both the read (strip) and the `push()` (prepend), so they cancel for any `ROOT_PATH`. Fixing it in the shared `RequireAuth` repairs every protected route at once.

## Verification

Built and ran the change locally under the `/sealog/` basename against the live backend:

- Home: logged-out load now captures `redirectPath = "/"` (was `/sealog/`) → after login lands on `…/sealog/` with the event-logging UI rendered.
- Deep link `/sealog/profile`: captures `redirectPath = "/profile"` → after login lands on `…/sealog/profile` (not `…/sealog/sealog/profile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)