### PR TITLE
Fix missing dive track in map view

### DIFF
--- a/src/components/lowering_map.js
+++ b/src/components/lowering_map.js
@@ -345,7 +345,7 @@ class LoweringMap extends Component {
           <Col className="px-1" sm={12}>
             <Card className="border-secondary">
               <LoweringMapDisplay 
-                loweringID={this.props.match.params.id}
+                loweringID={this.props.lowering.id}
                 selectedEvent={this.props.event.selected_event}
                 height={this.state.height}
                 renderPopup={() => (

--- a/src/components/lowering_map_display.js
+++ b/src/components/lowering_map_display.js
@@ -82,6 +82,9 @@ class LoweringMapDisplay extends Component {
         if (error.response && error.response.data.statusCode === 404) {
           console.warn("No", this.auxDatasourceFilters[index], "data found");
         }
+        else {
+          console.error("Error fetching", this.auxDatasourceFilters[index], "data:", error.message);
+        }
       });
 
       if (trackline.eventIDs.length > 0) {


### PR DESCRIPTION

`/lowering_map/<lowering_id>` renders an empty map, while the embedded map on `/lowering_replay/<lowering_id>` shows the dive track. Both use the same `LoweringMapDisplay` component.

The two call sites pass different kinds of ID:

- `lowering_replay.js` → `this.props.lowering.id` (database ID)
- `lowering_map.js` → `this.props.match.params.id` (semantic ID, e.g. `Alvin-D5249`)

This regressed when navigation switched to semantic IDs in 567c079 — replay and gallery were converted to the resolved `lowering.id`, but the map's `LoweringMapDisplay` call site was missed.

Tested and confirmed fix locally.